### PR TITLE
Implement authentication routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=example
 DB_NAME=fintrack
+# Secret key for signing JWT tokens
 JWT_SECRET=supersecret
 
 # Frontend configuration

--- a/backend/TESTS_AUTH.md
+++ b/backend/TESTS_AUTH.md
@@ -1,0 +1,31 @@
+# Suggested Test Cases for Authentication Routes
+
+The backend can be tested using Jest and Supertest. Below are example cases:
+
+1. **Registration Success**
+   - POST `/api/auth/register` with a valid email and password
+   - Expect `201` status and message `user created`
+   - Verify user exists in database
+
+2. **Registration Validation Failure**
+   - Missing or invalid email/password
+   - Expect `400` status with validation error details
+
+3. **Duplicate Registration**
+   - Register a user, then register again with the same email
+   - Expect `409` status and appropriate message
+
+4. **Login Success**
+   - POST `/api/auth/login` with correct credentials
+   - Expect `200` status and a JWT token in response
+
+5. **Login Failure**
+   - Incorrect password or unknown email
+   - Expect `401` status
+
+6. **JWT Protected Route**
+   - Call a protected endpoint (e.g. `/api/transactions/income`)
+   - Without token → expect `401`
+   - With valid token → expect success response
+
+Use Supertest to issue HTTP requests to the Express app and Jest assertions to verify responses.

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,9 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
-    "mysql2": "^3.7.0"
+    "mysql2": "^3.7.0",
+    "bcrypt": "^5.1.0",
+    "express-validator": "^7.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,11 @@
+import mysql from 'mysql2/promise';
+import 'dotenv/config';
+
+const pool = mysql.createPool({
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
+
+export default pool;

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  user?: { id: number; email: string };
+}
+
+export function authMiddleware(req: AuthRequest, res: Response, next: NextFunction) {
+  const authHeader = req.headers.authorization;
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'Missing token' });
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET as string);
+    req.user = payload as { id: number; email: string };
+    next();
+  } catch {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,16 +1,78 @@
 import { Router, Request, Response } from 'express';
+import { body, validationResult } from 'express-validator';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import pool from '../db.js';
 
 const router = Router();
 
-router.post('/login', (req: Request, res: Response) => {
-  // TODO: implement login logic
-  res.json({ token: 'dummy-token' });
-});
+router.post(
+  '/login',
+  body('email').isEmail(),
+  body('password').notEmpty(),
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
 
-router.post('/register', (req: Request, res: Response) => {
-  // TODO: implement registration logic
-  res.json({ message: 'user created' });
-});
+    const { email, password } = req.body as { email: string; password: string };
+    try {
+      const [rows] = await pool.query(
+        'SELECT id, password_hash FROM Users WHERE email = ? LIMIT 1',
+        [email],
+      );
+      if ((rows as any[]).length === 0) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const user = (rows as any)[0];
+      const match = await bcrypt.compare(password, user.password_hash);
+      if (!match) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const token = jwt.sign(
+        { id: user.id, email },
+        process.env.JWT_SECRET as string,
+        { expiresIn: '1h' },
+      );
+      res.json({ token });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
+
+router.post(
+  '/register',
+  body('email').isEmail(),
+  body('password').isLength({ min: 6 }),
+  async (req: Request, res: Response) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
+    const { email, password } = req.body as { email: string; password: string };
+    try {
+      const [exists] = await pool.query('SELECT id FROM Users WHERE email = ?', [
+        email,
+      ]);
+      if ((exists as any[]).length > 0) {
+        return res.status(409).json({ message: 'Email already registered' });
+      }
+      const hash = await bcrypt.hash(password, 10);
+      await pool.query(
+        'INSERT INTO Users (email, password_hash) VALUES (?, ?)',
+        [email, hash],
+      );
+      res.status(201).json({ message: 'user created' });
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ message: 'Server error' });
+    }
+  },
+);
 
 export default router;
 

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -1,5 +1,8 @@
 import { Router, Request, Response } from 'express';
+import { authMiddleware } from '../middleware/auth.js';
 const router = Router();
+
+router.use(authMiddleware);
 
 router.post('/income', (req: Request, res: Response) => {
   // TODO: store income in DB


### PR DESCRIPTION
## Summary
- add database connection helper
- implement JWT auth middleware and protected routes
- implement login & register routes with validations
- document recommended tests
- add bcrypt and express-validator dependencies
- note JWT secret usage in env file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a1fff9c88832995ec9db30afb1107