### PR TITLE
Implement income and expense tracking

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/backend/migrations/20240415_phase2.sql
+++ b/backend/migrations/20240415_phase2.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS Categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES Users(id)
+);
+
+CREATE TABLE IF NOT EXISTS Tags (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  name VARCHAR(50) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES Users(id)
+);
+
+CREATE TABLE IF NOT EXISTS Transactions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  type ENUM('income','expense') NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  category_id INT,
+  tag_id INT,
+  notes TEXT,
+  entry_date DATE NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES Users(id),
+  FOREIGN KEY (category_id) REFERENCES Categories(id),
+  FOREIGN KEY (tag_id) REFERENCES Tags(id)
+);
+
+CREATE TABLE IF NOT EXISTS TransactionTags (
+  transaction_id INT NOT NULL,
+  tag_id INT NOT NULL,
+  PRIMARY KEY(transaction_id, tag_id),
+  FOREIGN KEY (transaction_id) REFERENCES Transactions(id),
+  FOREIGN KEY (tag_id) REFERENCES Tags(id)
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,13 +1,12 @@
 {
   "name": "fintrack-backend",
   "version": "0.1.0",
-  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "nodemon --watch src --exec ts-node src/index.ts",
-    "test": "echo \"No tests\"",
+    "test": "jest",
     "lint": "eslint ."
   },
   "dependencies": {
@@ -29,6 +28,10 @@
     "nodemon": "^3.0.0",
     "prettier": "^3.6.2",
     "ts-node": "^10.9.1",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.2",
+    "@types/jest": "^29.5.11",
+    "supertest": "^6.3.4",
+    "ts-jest": "^29.1.1",
+    "jest": "^29.7.0"
   }
 }

--- a/backend/src/controllers/transactionController.ts
+++ b/backend/src/controllers/transactionController.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express';
+import { validationResult } from 'express-validator';
+import { AuthRequest } from '../middleware/auth.js';
+import {
+  addTransaction,
+  getTransactionsService,
+  getSummary,
+  getMonthlyBreakdown,
+} from '../services/transactionService.js';
+
+export async function createTransactionHandler(req: AuthRequest, res: Response) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ errors: errors.array() });
+  }
+  try {
+    const id = await addTransaction(req.user!.id, req.body);
+    res.status(201).json({ id });
+  } catch (err: any) {
+    if (err.message === 'Invalid category' || err.message === 'Invalid tag') {
+      return res.status(400).json({ message: err.message });
+    }
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+}
+
+export async function listTransactionsHandler(req: AuthRequest, res: Response) {
+  try {
+    const data = await getTransactionsService(req.user!.id, {
+      start: req.query.start as string | undefined,
+      end: req.query.end as string | undefined,
+      category: req.query.category ? Number(req.query.category) : undefined,
+    });
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+}
+
+export async function summaryHandler(req: AuthRequest, res: Response) {
+  try {
+    const data = await getSummary(req.user!.id);
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+}
+
+export async function monthlyHandler(req: AuthRequest, res: Response) {
+  const month = (req.query.month as string) || new Date().toISOString().slice(0, 7);
+  try {
+    const data = await getMonthlyBreakdown(req.user!.id, month);
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,11 @@ requiredEnv.forEach((v) => {
 });
 
 const port = process.env.PORT || 3001;
-app.listen(port, () => {
-  console.log(`Backend running on port ${port}`);
-});
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Backend running on port ${port}`);
+  });
+}
+
+export default app;

--- a/backend/src/models/category.ts
+++ b/backend/src/models/category.ts
@@ -1,0 +1,9 @@
+import pool from '../db.js';
+
+export async function categoryExists(userId: number, id: number) {
+  const [rows] = await pool.query(
+    'SELECT id FROM Categories WHERE id = ? AND user_id = ? LIMIT 1',
+    [id, userId],
+  );
+  return (rows as any[]).length > 0;
+}

--- a/backend/src/models/tag.ts
+++ b/backend/src/models/tag.ts
@@ -1,0 +1,9 @@
+import pool from '../db.js';
+
+export async function tagExists(userId: number, id: number) {
+  const [rows] = await pool.query(
+    'SELECT id FROM Tags WHERE id = ? AND user_id = ? LIMIT 1',
+    [id, userId],
+  );
+  return (rows as any[]).length > 0;
+}

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -1,0 +1,79 @@
+import pool from '../db.js';
+
+export interface Transaction {
+  id?: number;
+  user_id: number;
+  type: 'income' | 'expense';
+  amount: number;
+  category_id?: number | null;
+  tag_id?: number | null;
+  notes?: string | null;
+  entry_date: string; // ISO date string
+}
+
+export async function createTransaction(tx: Transaction) {
+  const [result] = await pool.query(
+    'INSERT INTO Transactions (user_id, type, amount, category_id, tag_id, notes, entry_date) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [
+      tx.user_id,
+      tx.type,
+      tx.amount,
+      tx.category_id ?? null,
+      tx.tag_id ?? null,
+      tx.notes ?? null,
+      tx.entry_date,
+    ],
+  );
+  return (result as any).insertId as number;
+}
+
+export async function listTransactions(
+  userId: number,
+  opts: { start?: string; end?: string; category?: number },
+) {
+  let query = 'SELECT * FROM Transactions WHERE user_id = ?';
+  const params: any[] = [userId];
+  if (opts.category) {
+    query += ' AND category_id = ?';
+    params.push(opts.category);
+  }
+  if (opts.start) {
+    query += ' AND entry_date >= ?';
+    params.push(opts.start);
+  }
+  if (opts.end) {
+    query += ' AND entry_date <= ?';
+    params.push(opts.end);
+  }
+  query += ' ORDER BY entry_date DESC';
+  const [rows] = await pool.query(query, params);
+  return rows as Transaction[];
+}
+
+export async function getSummary(userId: number) {
+  const [rows] = await pool.query(
+    `SELECT
+      SUM(CASE WHEN type='income' THEN amount ELSE 0 END) AS income,
+      SUM(CASE WHEN type='expense' THEN amount ELSE 0 END) AS expenses
+    FROM Transactions WHERE user_id = ?`,
+    [userId],
+  );
+  const row = (rows as any)[0] || { income: 0, expenses: 0 };
+  return {
+    income: Number(row.income) || 0,
+    expenses: Number(row.expenses) || 0,
+    savings: (Number(row.income) || 0) - (Number(row.expenses) || 0),
+  };
+}
+
+export async function getMonthlyBreakdown(userId: number, month: string) {
+  const [rows] = await pool.query(
+    `SELECT c.name as category, SUM(t.amount) as total
+     FROM Transactions t
+     LEFT JOIN Categories c ON t.category_id = c.id
+     WHERE t.user_id = ? AND DATE_FORMAT(t.entry_date, '%Y-%m') = ?
+     GROUP BY c.name`,
+    [userId, month],
+  );
+  return rows as { category: string; total: number }[];
+}

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -1,18 +1,36 @@
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
+import { body, query } from 'express-validator';
 import { authMiddleware } from '../middleware/auth.js';
-const router = Router();
+import {
+  createTransactionHandler,
+  listTransactionsHandler,
+  summaryHandler,
+  monthlyHandler,
+} from '../controllers/transactionController.js';
 
+const router = Router();
 router.use(authMiddleware);
 
-router.post('/income', (req: Request, res: Response) => {
-  // TODO: store income in DB
-  res.json({ message: 'income logged' });
-});
+router.post(
+  '/',
+  body('type').isIn(['income', 'expense']),
+  body('amount').isFloat({ gt: 0 }),
+  body('category_id').optional().isInt(),
+  body('tag_id').optional().isInt(),
+  body('notes').optional().isString(),
+  body('entry_date').isISO8601(),
+  createTransactionHandler,
+);
 
-router.post('/expense', (req: Request, res: Response) => {
-  // TODO: store expense in DB
-  res.json({ message: 'expense logged' });
-});
+router.get(
+  '/',
+  query('start').optional().isISO8601(),
+  query('end').optional().isISO8601(),
+  query('category').optional().isInt(),
+  listTransactionsHandler,
+);
+
+router.get('/summary', summaryHandler);
+router.get('/monthly', monthlyHandler);
 
 export default router;
-

--- a/backend/src/services/transactionService.ts
+++ b/backend/src/services/transactionService.ts
@@ -1,0 +1,31 @@
+import { categoryExists } from '../models/category.js';
+import { tagExists } from '../models/tag.js';
+import {
+  Transaction,
+  createTransaction,
+  listTransactions,
+  getSummary,
+  getMonthlyBreakdown,
+} from '../models/transaction.js';
+
+export async function addTransaction(userId: number, data: Omit<Transaction, 'id' | 'user_id'>) {
+  if (data.category_id) {
+    const exists = await categoryExists(userId, data.category_id);
+    if (!exists) throw new Error('Invalid category');
+  }
+  if (data.tag_id) {
+    const exists = await tagExists(userId, data.tag_id);
+    if (!exists) throw new Error('Invalid tag');
+  }
+  const id = await createTransaction({ ...data, user_id: userId });
+  return id;
+}
+
+export async function getTransactionsService(
+  userId: number,
+  opts: { start?: string; end?: string; category?: number },
+) {
+  return listTransactions(userId, opts);
+}
+
+export { getSummary, getMonthlyBreakdown };

--- a/backend/tests/transactions.test.ts
+++ b/backend/tests/transactions.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/index.js';
+
+jest.mock('../src/db.js', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}));
+
+const pool = require('../src/db.js').default;
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
+});
+
+beforeEach(() => {
+  (pool.query as jest.Mock).mockReset();
+});
+
+describe('Transactions API', () => {
+  const token = jwt.sign({ id: 1, email: 'test@example.com' }, 'testsecret');
+
+  test('valid transaction creation', async () => {
+    (pool.query as jest.Mock).mockResolvedValueOnce([{ insertId: 1 }]);
+    const res = await request(app)
+      .post('/api/transactions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'income', amount: 100, entry_date: '2024-01-01' });
+    expect(res.status).toBe(201);
+  });
+
+  test('unauthorized access', async () => {
+    const res = await request(app).get('/api/transactions');
+    expect(res.status).toBe(401);
+  });
+
+  test('invalid inputs', async () => {
+    const res = await request(app)
+      .post('/api/transactions')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ type: 'income', amount: -5, entry_date: '2024-01-01' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ESNext",
+    "module": "CommonJS",
     "rootDir": "src",
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add SQL migrations for Categories, Tags, Transactions and TransactionTags
- implement transaction controller, service, and models
- wire up new /api/transactions routes
- export app from index for testing
- configure Jest and add tests
- switch backend build to CommonJS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a2633920483298a0a14067b519a54